### PR TITLE
Fix TMT 16-plex and 18-plex both mapping to Tmt11

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -418,8 +418,8 @@ impl IsobarSelection {
         ui.radio_value(&mut self.selected, Isobaric::Tmt6, "TMT 6-plex");
         ui.radio_value(&mut self.selected, Isobaric::Tmt10, "TMT 10-plex");
         ui.radio_value(&mut self.selected, Isobaric::Tmt11, "TMT 11-plex");
-        ui.radio_value(&mut self.selected, Isobaric::Tmt11, "TMT 16-plex");
-        ui.radio_value(&mut self.selected, Isobaric::Tmt11, "TMT 18-plex");
+        ui.radio_value(&mut self.selected, Isobaric::Tmt16, "TMT 16-plex");
+        ui.radio_value(&mut self.selected, Isobaric::Tmt18, "TMT 18-plex");
     }
 }
 


### PR DESCRIPTION
The 16-plex and 18-plex radio buttons both set Isobaric::Tmt11, so picking either one silently runs the search as TMT 11-plex instead. This points them at Isobaric::Tmt16 and Isobaric::Tmt18 respectively.

Found and fixed while working on a downstream fork; splitting it out as its own PR since it's unrelated to anything else in that fork.