### PR TITLE
Fix fragment tolerance unit switch writing to precursor_tol

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -717,10 +717,10 @@ impl SageLauncher {
 
             match (self.fragment_tolerance_type, self.config.fragment_tol) {
                 (ToleranceType::Ppm, ToleranceConfig::Da(..)) => {
-                    self.config.precursor_tol = self.fragment_tolerance_type.get_default_tolerance()
+                    self.config.fragment_tol = self.fragment_tolerance_type.get_default_tolerance()
                 }
                 (ToleranceType::Da, ToleranceConfig::Ppm(..)) => {
-                    self.config.precursor_tol = self.fragment_tolerance_type.get_default_tolerance()
+                    self.config.fragment_tol = self.fragment_tolerance_type.get_default_tolerance()
                 }
                 _ => {}
             }


### PR DESCRIPTION
When the fragment tolerance unit toggles between ppm and Da, the default-tolerance assignment lands on self.config.precursor_tol instead of self.config.fragment_tol, so switching fragment tolerance units silently changes the precursor tolerance instead.

Same fork as the TMT plex PR, split out separately since it's a distinct bug.